### PR TITLE
Use UITextView's delegate to detect URL taps

### DIFF
--- a/Sources/AttributedText/AttributedTextImpl+iOS.swift
+++ b/Sources/AttributedText/AttributedTextImpl+iOS.swift
@@ -36,13 +36,11 @@
         self.backgroundColor = .clear
         self.textContainerInset = .zero
         self.isEditable = false
-        self.isSelectable = false
+        self.isSelectable = true
         self.isScrollEnabled = false
+        self.isUserInteractionEnabled = true
+        self.delegate = self
         self.textContainer.lineFragmentPadding = 0
-
-        self.addGestureRecognizer(
-          UITapGestureRecognizer(target: self, action: #selector(handleTap(sender:)))
-        )
       }
 
       required init?(coder: NSCoder) {
@@ -56,32 +54,12 @@
 
         return sizeThatFits(CGSize(width: maxLayoutWidth, height: .greatestFiniteMagnitude))
       }
-
-      @objc func handleTap(sender: UITapGestureRecognizer) {
-        guard let url = self.url(at: sender.location(in: self)) else {
-          return
-        }
-        openLink?(url)
-      }
-
-      private func url(at location: CGPoint) -> URL? {
-        guard let attributedText = self.attributedText else { return nil }
-
-        let index = indexOfCharacter(at: location)
-        return attributedText.attribute(.link, at: index, effectiveRange: nil) as? URL
-      }
-
-      private func indexOfCharacter(at location: CGPoint) -> Int {
-        let locationInTextContainer = CGPoint(
-          x: location.x - self.textContainerInset.left,
-          y: location.y - self.textContainerInset.top
-        )
-        return self.layoutManager.characterIndex(
-          for: locationInTextContainer,
-          in: self.textContainer,
-          fractionOfDistanceBetweenInsertionPoints: nil
-        )
-      }
     }
-  }
+    
+    extension AttributedTextImpl: UITextViewDelegate {
+      func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        openLink?(URL)
+        return false
+      }      
+    }
 #endif


### PR DESCRIPTION
# Description
In some particular cases taping on URLs would not register and the text would sudenly change line spacing, it seems that the main culprit was the custom URL tap handler.

## Updates
Switched from the custom URL tap location detection to the built-in UITextView's built in `func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool`.
